### PR TITLE
Fix problem with `bl` types, reactivate tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "typescript": "~4.8.4"
   },
   "dependencies": {
-    "@types/bl": "^5.0.2",
+    "@types/bl": "~5.0.2",
     "@types/lru-cache": "^5.1.1",
     "bl": "^5.0.0",
     "capitalize": "^2.0.4",

--- a/test/blockwise.ts
+++ b/test/blockwise.ts
@@ -364,7 +364,7 @@ describe('blockwise2', function () {
         parallelBlock2Test(done, checkNothing, checkBlock2Payload, checkNormalRespPayload)
     })
 
-    it.only('should support the Size2 option', function (done) {
+    it('should support the Size2 option', function (done) {
         request({
             port
         })


### PR DESCRIPTION
This PR is a subset of #356, including the most important fix for `@types/bl` and reactivating the inactive tests. I'll rebase #356 once this one is merged – I had some problems getting the updated dependencies to work on Node 14 for some reason :/