### PR TITLE
refactor: apply minor refactorings to agent and server

### DIFF
--- a/lib/agent.ts
+++ b/lib/agent.ts
@@ -400,8 +400,6 @@ class Agent extends EventEmitter {
         const port = url.port ?? parameters.coapPort
 
         const req = new OutgoingMessage({}, (req, packet) => {
-            let buf
-
             if (url.confirmable !== false) {
                 packet.confirmable = true
             }
@@ -441,6 +439,7 @@ class Agent extends EventEmitter {
                 req.segmentedSender = new SegmentedTransmission(block1Buff[0], req, packet)
                 req.segmentedSender.sendNext()
             } else {
+                let buf: Buffer
                 try {
                     buf = generate(packet)
                 } catch (err) {

--- a/lib/server.ts
+++ b/lib/server.ts
@@ -502,12 +502,9 @@ class CoAPServer extends EventEmitter {
         if (packet.token != null && packet.token.length > 0) {
             // return cached value only if this request is not the first block request
             const block2Buff = getOption(packet.options, 'Block2')
-            let requestedBlockOption
+            let requestedBlockOption: Block = { num: 0, more: 0, size: 0 }
             if (block2Buff instanceof Buffer) {
-                requestedBlockOption = parseBlock2(block2Buff)
-            }
-            if (requestedBlockOption == null) {
-                requestedBlockOption = { num: 0 }
+                requestedBlockOption = parseBlock2(block2Buff) ?? requestedBlockOption
             }
             if (cacheKey == null) {
                 return

--- a/lib/server.ts
+++ b/lib/server.ts
@@ -27,13 +27,11 @@ import Debug from 'debug'
 const debug = Debug('CoAP Server')
 
 function handleEnding (err: Error): void {
-    // eslint-disable-next-line @typescript-eslint/no-this-alias
-    const request = this
     if (err != null) {
-        request.server._sendError(
+        this.server._sendError(
             Buffer.from(err.message),
-            request.rsinfo,
-            request.packet
+            this.rsinfo,
+            this.packet
         )
     }
 }


### PR DESCRIPTION
This PR applies a few minor refactorings to `agent.ts` and `server.ts`, making the code slightly more readable.