### PR TITLE
chore: remove pre-commit hook

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,9 +17,6 @@
     "type": "git",
     "url": "https://github.com/coapjs/node-coap.git"
   },
-  "pre-commit": [
-    "test"
-  ],
   "keywords": [
     "coap",
     "m2m",
@@ -50,7 +47,6 @@
     "eslint-plugin-promise": "^6.1.0",
     "mocha": "^10.1.0",
     "c8": "^7.12.0",
-    "pre-commit": "1.2.2",
     "sinon": "^12.0.1",
     "source-map-support": "^0.5.21",
     "timekeeper": "^2.2.0",


### PR DESCRIPTION
So far, a pre-commit hook was triggered by default that ran `npm test` whenever you committed. I personally found this a bit annoying and always removed the hooks manually, but due to the configuration in `package.json`, they are always reinstalled whenever you invoke `npm install`.

This PR gets rid of the hooks by removing the `pre-commit` dependency and the `pre-commit` field in `package.json`. This gives us developers a bit more control without sacrificing code quality here on GitHub since the CI action is running anyway, ensuring that the code base passes all tests.

This is just a personal preference, though, if you would like to keep the hooks, we could also leave them as is and close this PR :)