### PR TITLE
Do not include network aliases (identified by same MAC)

### DIFF
--- a/lib/server.ts
+++ b/lib/server.ts
@@ -69,6 +69,7 @@ function allAddresses (type): string[] {
     for (const ifname in interfaces) {
         if (ifname in interfaces) {
             interfaces[ifname]?.forEach((a) => {
+                // Checking for repeating MAC address to avoid trying to listen on same interface twice
                 if (a.family === family && !macs.includes(a.mac)) {
                     addresses.push(a.address)
                     macs.push(a.mac)

--- a/lib/server.ts
+++ b/lib/server.ts
@@ -64,12 +64,14 @@ function allAddresses (type): string[] {
         family = 'IPv6'
     }
     const addresses: string[] = []
+    const macs: string[] = []
     const interfaces = os.networkInterfaces()
     for (const ifname in interfaces) {
         if (ifname in interfaces) {
             interfaces[ifname]?.forEach((a) => {
-                if (a.family === family) {
+                if (a.family === family && macs.includes(a.mac) == false) {
                     addresses.push(a.address)
+                    macs.push(a.address)
                 }
             })
         }

--- a/lib/server.ts
+++ b/lib/server.ts
@@ -69,7 +69,7 @@ function allAddresses (type): string[] {
     for (const ifname in interfaces) {
         if (ifname in interfaces) {
             interfaces[ifname]?.forEach((a) => {
-                if (a.family === family && macs.includes(a.mac) == false) {
+                if (a.family === family && !macs.includes(a.mac)) {
                     addresses.push(a.address)
                     macs.push(a.address)
                 }

--- a/lib/server.ts
+++ b/lib/server.ts
@@ -71,7 +71,7 @@ function allAddresses (type): string[] {
             interfaces[ifname]?.forEach((a) => {
                 if (a.family === family && !macs.includes(a.mac)) {
                     addresses.push(a.address)
-                    macs.push(a.address)
+                    macs.push(a.mac)
                 }
             })
         }


### PR DESCRIPTION
Starting a listener on a network alias fails, so do not include them in allAddresses function.