### PR TITLE
chore: update lru-cache dependency, update Node versions in CI

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -13,7 +13,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [14.x]
+        node-version: [18.x]
         os: [ubuntu-latest]
 
     steps:

--- a/.github/workflows/npm-test.yml
+++ b/.github/workflows/npm-test.yml
@@ -18,7 +18,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [14.x, 16.x, 18.x]
+        node-version: [18.x, 20.x]
         os: [ubuntu-latest, windows-latest, macos-latest]
 
     steps:

--- a/package.json
+++ b/package.json
@@ -54,14 +54,14 @@
     "typescript": "^4.9.3"
   },
   "dependencies": {
-    "@types/lru-cache": "^5.1.1",
+    "@types/lru-cache": "^7.10.10",
     "bl": "^6.0.0",
     "@types/readable-stream": "^2.3.15",
     "capitalize": "^2.0.4",
     "coap-packet": "^1.1.1",
     "debug": "^4.3.4",
     "fastseries": "^2.0.0",
-    "lru-cache": "^6.0.0",
+    "lru-cache": "^10.0.3",
     "readable-stream": "^4.2.0"
   },
   "engines": {

--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     "readable-stream": "^4.2.0"
   },
   "engines": {
-    "node": ">=12"
+    "node": ">=18"
   },
   "files": [
     "dist/index.d.ts",

--- a/test/server.ts
+++ b/test/server.ts
@@ -1222,14 +1222,14 @@ describe('server LRU', function () {
         server.on('request', (req, res) => {
             res.end()
 
-            expect(server._lru.itemCount).to.be.equal(1)
+            expect(server._lru.size).to.be.equal(1)
 
             clock.tick(parameters.exchangeLifetime * 500)
 
-            expect(server._lru.itemCount).to.be.equal(1)
+            expect(server._lru.size).to.be.equal(1)
 
             clock.tick(parameters.exchangeLifetime * 1000)
-            expect(server._lru.itemCount).to.be.equal(0)
+            expect(server._lru.size).to.be.equal(0)
             done()
         })
     })


### PR DESCRIPTION
Spin-off from #373 that upgrades the `lru-cache`, because it is a bit tedious to debug otherwise.

Also updates the Node versions used by the CI, since the most recent `lru-cache` version seems to be incompatible with Node 14. Since Node 14 is EOL by way, applying this update might be overdue anyway.