### PR TITLE
Fix blockwise response logic

### DIFF
--- a/lib/parameters.ts
+++ b/lib/parameters.ts
@@ -131,6 +131,12 @@ const NON_LIFETIME = 145
 const COAP_PORT = 5683
 
 /**
+ * Maximum total size of the CoAP application layer message, as
+ * recommended by the CoAP specification
+ */
+const MAX_MESSAGE_SIZE = 1152
+
+/**
  * Default max payload size recommended in the CoAP specification
  * For more info see RFC 7252 Section 4.6
  */
@@ -178,6 +184,7 @@ const p: Parameters = {
     nonLifetime: NON_LIFETIME,
     coapPort: COAP_PORT,
     maxPayloadSize: MAX_PAYLOAD_SIZE,
+    maxMessageSize: MAX_MESSAGE_SIZE,
     sendAcksForNonConfirmablePackets,
     piggybackReplyMs,
     pruneTimerPeriod

--- a/lib/parameters.ts
+++ b/lib/parameters.ts
@@ -131,9 +131,10 @@ const NON_LIFETIME = 145
 const COAP_PORT = 5683
 
 /**
- * Default max packet size based on IP MTU.
+ * Default max payload size recommended in the CoAP specification
+ * For more info see RFC 7252 Section 4.6
  */
-const IP_MTU = 1280
+const MAX_PAYLOAD_SIZE = 1024
 
 /* Custom default parameters */
 
@@ -176,7 +177,7 @@ const p: Parameters = {
     maxLatency: MAX_LATENCY,
     nonLifetime: NON_LIFETIME,
     coapPort: COAP_PORT,
-    maxPacketSize: IP_MTU,
+    maxPayloadSize: MAX_PAYLOAD_SIZE,
     sendAcksForNonConfirmablePackets,
     piggybackReplyMs,
     pruneTimerPeriod

--- a/models/models.ts
+++ b/models/models.ts
@@ -54,6 +54,7 @@ export interface ParametersUpdate {
     maxLatency?: number
     piggybackReplyMs?: number
     maxPayloadSize?: number
+    maxMessageSize?: number
     sendAcksForNonConfirmablePackets?: boolean
     pruneTimerPeriod?: number
 }
@@ -70,6 +71,7 @@ export interface Parameters {
     nonLifetime: number
     coapPort: number
     maxPayloadSize: number
+    maxMessageSize: number
     sendAcksForNonConfirmablePackets: boolean
     pruneTimerPeriod: number
     maxTransmitSpan: number

--- a/models/models.ts
+++ b/models/models.ts
@@ -53,7 +53,7 @@ export interface ParametersUpdate {
     probingRate?: number
     maxLatency?: number
     piggybackReplyMs?: number
-    maxPacketSize?: number
+    maxPayloadSize?: number
     sendAcksForNonConfirmablePackets?: boolean
     pruneTimerPeriod?: number
 }
@@ -69,7 +69,7 @@ export interface Parameters {
     piggybackReplyMs: number
     nonLifetime: number
     coapPort: number
-    maxPacketSize: number
+    maxPayloadSize: number
     sendAcksForNonConfirmablePackets: boolean
     pruneTimerPeriod: number
     maxTransmitSpan: number

--- a/test/blockwise.ts
+++ b/test/blockwise.ts
@@ -83,7 +83,7 @@ describe('blockwise2', function () {
         })
     })
 
-    it('should use blockwise in response when payload bigger than max packet', function (done) {
+    it('should use blockwise in response when payload bigger than max payload', function (done) {
         const payload = Buffer.alloc(1275) // 1275 produces a CoAP message (after headers) > 1280
         request({
             port

--- a/test/blockwise.ts
+++ b/test/blockwise.ts
@@ -59,7 +59,7 @@ describe('blockwise2', function () {
     }
 
     it('should server not use blockwise in response when payload fit in one packet', function (done) {
-        const payload = Buffer.alloc(100) // default max packet is 1280
+        const payload = Buffer.alloc(100) // default max payload is 1024
 
         request({
             port

--- a/test/blockwise.ts
+++ b/test/blockwise.ts
@@ -65,6 +65,7 @@ describe('blockwise2', function () {
             port
         })
             .on('response', (res) => {
+                expect(res.code).to.eq('2.05')
                 let blockwiseResponse = false
                 for (const i in res.options) {
                     if (res.options[i].name === 'Block2') {
@@ -83,10 +84,12 @@ describe('blockwise2', function () {
     })
 
     it('should use blockwise in response when payload bigger than max packet', function (done) {
+        const payload = Buffer.alloc(1275) // 1275 produces a CoAP message (after headers) > 1280
         request({
             port
         })
             .on('response', (res) => {
+                expect(res.code).to.eq('2.05')
                 let blockwiseResponse = false
                 for (const i in res.options) {
                     if (res.options[i].name === 'Block2') {
@@ -109,6 +112,7 @@ describe('blockwise2', function () {
             port
         })
             .on('response', (res) => {
+                expect(res.code).to.eq('2.05')
                 expect(typeof res.headers.ETag).to.eql('string')
                 // expect(cache.get(res._packet.token.toString())).to.not.be.undefined
                 setImmediate(done)
@@ -125,6 +129,7 @@ describe('blockwise2', function () {
         })
             .setOption('Block2', Buffer.of(0x02))
             .on('response', (res) => {
+                expect(res.code).to.eq('2.05')
                 let block2
                 for (const i in res.options) {
                     if (res.options[i].name === 'Block2') {
@@ -184,6 +189,7 @@ describe('blockwise2', function () {
         })
             .setOption('Block2', Buffer.of(0x10)) // request from block 1, with size = 16
             .on('response', (res) => {
+                expect(res.code).to.eq('2.05')
                 expect(res.payload).to.eql(payload.slice(1 * 16, payload.length + 1))
                 // expect(cache.get(res._packet.token.toString())).to.not.be.undefined
                 setImmediate(done)
@@ -201,6 +207,7 @@ describe('blockwise2', function () {
         })
             .setOption('Block2', Buffer.of(0x0)) // early negotation with block size = 16, almost 10000/16 = 63 blocks
             .on('response', (res) => {
+                expect(res.code).to.eq('2.05')
                 expect(res.payload).to.eql(payload)
                 // expect(cache.get(res._packet.token.toString())).to.not.be.undefined
                 setImmediate(done)


### PR DESCRIPTION
## Overview

This is a fix for #375 where the server will attempt to generate a packet greater than the maximum allowable, which was set to 1280 bytes. This would occur if the size of the payload was less than 1280 bytes, but the size of the resulting CoAP message was greater than 1280 bytes after the headers were added.

The bug was introduced 9 years ago in d727d430d7c744a516d4c68d156ed6bf8262f7b7 and has some incorrect logic for dealing with message sizes. It would be very easy to simply revert those changes and call it a fix, but I wanted to try and understand what the author was trying to implement and to fix the implementation, rather than simply removing functionality.

In addition I've updated the tests to be more robust and to catch errors like this in the future.

## Motivation and Context

The intent of the above commit, I believe, was to allow the maximum packet size to be adjusted for cases where the server is running over a network stack that has an MTU different to that of ethernet. A 6LoWPAN/Thread network stack, for example, will have an MTU significantly less than that of ethernet so the server can be configured to perform blockwise transfers earlier to avoid message fragmentation at the IP layer. This is done with an `IP_MTU` constant and a `maxPacketSize` parameter that control when blockwise transfers are applied.

Unfortunately the phrase 'packet' and 'MTU' are used all over the place and don't really refer to anything meaningful in the context of the application layer. The IP MTU is the size of the whole IP packet, including all headers and payload. The `IP_MTU` constant defaults to 1280 and is used only to check the CoAP payload, missing the CoAP headers, UDP header, and IP header when performing the check.

The CoAP specification does not ever refer to anything as a 'packet' - it refers to 'messages'. A 'packet' is the IP layer 3 data unit, and I think this ambiguity of naming in the library has caused confusion in the past when features are implemented.

## Changes Introduced

Even though the maximum CoAP message size is _based_ on the IP MTU, it's not practical to try and determine the MTU for every response and apply blockwise logic accordingly. Furthermore the header size of the IP layer is not fixed, and when using 6LoWPAN neither is the UDP header size. So instead the changes here follow the recommendations set out in [RFC 7252 Section 4.6](https://datatracker.ietf.org/doc/html/rfc7252#section-4.6) which state:

> If the Path MTU is not known for a destination, an IP MTU of 1280
> bytes SHOULD be assumed; if nothing is known about the size of the
> headers, good upper bounds are 1152 bytes for the message size and
> 1024 bytes for the payload size.

Those recommendations are reflected in the defaults that are implemented, and can be adjusted from the server parameters.


### Tests

Update tests in `test/blockwise.ts` to check the response code of the server when checking responses and to move the test payload size to within the bounds of the edge case that this is fixing.

### Server Code

Change the parameters file to remove the `IP_MTU` constant. This was replaced with two constants: `MAX_PAYLOAD_SIZE` and `MAX_MESSAGE_SIZE`. Those changes are reflected in the parameters by removing the `maxPacketSize`, replacing it with `maxPayloadSize` and `maxMessageSize` respectively.

The blockwise logic has been updated to be more efficient and understandable, using the provided `maxPayloadSize` parameter. The check for whether a response needs to be split into blocks is now correct, fixing the initial bug.

The `maxMessageSize` parameter is used when calling [`coap-packet:generate()`](https://github.com/coapjs/coap-packet/blob/61ffea1059c0ee005c60bcb9e904455dc2065bdd/index.js#L31) and is passed as the `maxLength` argument. This argument, when not explicitly passed, defaults to 1280 which (as discussed) does not represent the maximum allowable message size. Now an error will be returned from that function when the total CoAP message size is greater than the max allowable set in the server. This error should now only occur if the server is misconfigured.

## Potentially Breaking Changes

The changes to the parameters might be breaking changes, depending on how they are used in other projects. I'm happy to rename them if required in order to maintain some form of backwards compatibility, at the expense of the names being less clear.