### PR TITLE
Fixed build issuee  can only be default-imported using the 'esModuleI…

### DIFF
--- a/lib/outgoing_message.ts
+++ b/lib/outgoing_message.ts
@@ -14,6 +14,7 @@ import { SegmentedTransmission } from './segmentation'
 import IncomingMessage from './incoming_message'
 import { OptionName, Packet } from 'coap-packet'
 
+
 export default class OutgoingMessage extends BufferListStream {
     _packet: Packet
     _ackTimer: NodeJS.Timeout | null

--- a/lib/outgoing_message.ts
+++ b/lib/outgoing_message.ts
@@ -6,7 +6,7 @@
  * See the included LICENSE file for more details.
  */
 
-import BufferListStream from 'bl'
+import { BufferListStream } from 'bl'
 import { CoapPacket, CoapRequestParams, OptionValue } from '../models/models'
 import { genAck, toCode, setOption } from './helpers'
 import RetrySend from './retry_send'

--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "coap-packet": "^1.1.1",
     "debug": "^4.3.4",
     "fastseries": "^2.0.0",
-    "lru-cache": "^10.0.3",
+    "lru-cache": "^10.2.0",
     "readable-stream": "^4.2.0"
   },
   "engines": {

--- a/package.json
+++ b/package.json
@@ -54,7 +54,6 @@
     "typescript": "^5.2.2"
   },
   "dependencies": {
-    "@types/lru-cache": "^7.10.10",
     "bl": "^6.0.0",
     "@types/readable-stream": "^2.3.15",
     "capitalize": "^2.0.4",


### PR DESCRIPTION
node_modules/coap/dist/lib/outgoing_message.d.ts:3:8 - error TS1259: Module '"/x/node_modules/bl/index"' can only be default-imported using the 'esModuleInterop' flag

3 import BufferListStream from 'bl';
         ~~~~~~~~~~~~~~~~