### PR TITLE
Bump lru-cache version to 11.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "coap-packet": "^1.1.1",
     "debug": "^4.3.5",
     "fastseries": "^2.0.0",
-    "lru-cache": "^10.2.2",
+    "lru-cache": "^11.0.2",
     "readable-stream": "^4.5.2"
   },
   "engines": {


### PR DESCRIPTION
As explained in https://github.com/isaacs/node-lru-cache/issues/354 old versions of lru-cache (<= 11.0.0) caused problems with new typescript releases (5.6.x). This PR upgrades the dependency to 11.0.x. 