### PR TITLE
chore: bump version to 1.4.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "coap",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "description": "A CoAP library for node modelled after 'http'",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
This PR bumps the package's version to 1.4.1 in preparation of a new release. As @Apollon77 already agreed to publish a new patch release with the current state of the `master` branch in https://github.com/coapjs/node-coap/pull/392#issuecomment-2603239422, I will merge this one immediately.