### PR TITLE
Fix Block1 transfer handling for non-piggybacked responses

### DIFF
--- a/lib/agent.ts
+++ b/lib/agent.ts
@@ -228,9 +228,10 @@ class Agent extends EventEmitter {
 
         req.sender.reset()
 
-        if (block1 != null && packet.ack) {
+        if (block1 != null) {
         // If the client takes too long to respond then the retry sender will send
         // another packet with the previous messageId, which we've already removed.
+        // Handle both piggybacked (ACK with Block1) and non-piggybacked (CON with Block1) responses
             const segmentedSender = req.segmentedSender
             if (segmentedSender != null) {
                 // If there's more to send/receive, then carry on!


### PR DESCRIPTION
### Problem
The node-coap client was incorrectly handling Block1 transfers when servers send non-piggybacked responses. Specifically, when a server:
1. Sends an ACK without Block1 option
2. Then sends a separate CON/NON message with Block1 response

The client would prematurely complete the Block1 transfer because it only processed Block1 options on ACK messages.

### Root Cause
The condition `if (block1 != null && packet.ack)` in `lib/agent.ts` was too restrictive. It only processed Block1 options when the packet was an ACK, but RFC 7959 allows Block1 responses to be sent as separate messages (non-piggybacked).

### Solution
Changed the condition to `if (block1 != null)` to process Block1 options regardless of message type. This handles:
- **Piggybacked responses**: ACK with Block1 option
- **Non-piggybacked responses**: Separate CON/NON messages with Block1 option

### RFC Compliance
According to RFC 7959 (Block Transfer), Block1 responses can be sent either:
- Piggybacked on ACK messages
- As separate confirmable or non-confirmable messages

The fix ensures compliance with both approaches.

### Testing
- Verified the fix handles both piggybacked and non-piggybacked Block1 responses
- Maintains backward compatibility with existing ACK-based Block1 handling
- No breaking changes to the public API

### Files Changed
- `lib/agent.ts`: Modified Block1 processing condition to handle all message types

This fix resolves issues when communicating with third-party CoAP servers that implement non-piggybacked Block1 responses.