### PR TITLE
fix: preserve Uri-Query on OSCORE Echo auto-retry

### DIFF
--- a/lib/agent.ts
+++ b/lib/agent.ts
@@ -447,9 +447,13 @@ class Agent extends EventEmitter {
                     const retryUrl = { ...req.url, token: req._packet.token }
                     const retryReq = this.request(retryUrl)
 
-                    // Carry over options from original packet (Content-Format, Accept, custom, etc.)
-                    // Skip Uri-Path, Uri-Query, Observe — these are reconstructed from retryUrl by request()
-                    const skipOptions = new Set(['Uri-Path', 'Uri-Query', 'Observe'])
+                    // Carry over options from original packet (Content-Format, Accept,
+                    // Uri-Query, custom, etc.). Skip only Uri-Path and Observe — those
+                    // are reconstructed from retryUrl by request() (via url.pathname /
+                    // url.observe). Uri-Query has no such reconstruction path: it is
+                    // only ever set via setOption() on the original request, so it
+                    // must be copied here or the retry silently loses it (GWLB-2727).
+                    const skipOptions = new Set(['Uri-Path', 'Observe'])
                     if (req._packet.options != null) {
                         for (const opt of req._packet.options) {
                             if (!skipOptions.has(String(opt.name))) {

--- a/test/oscore.ts
+++ b/test/oscore.ts
@@ -1309,4 +1309,104 @@ describe('OSCORE', function () {
             })
         }).timeout(2000)
     })
+
+    describe('client-side Echo auto-retry', function () {
+        it('should preserve Uri-Query options when auto-retrying after a 4.01 Echo challenge (GWLB-2727)', function (done) {
+            const port = nextPort()
+            const { client: clientOscore, server: serverOscore } = createOscorePair()
+
+            const fakeServer = dgram.createSocket('udp4')
+            let requestCount = 0
+            let finished = false
+            const finish = (err?: Error): void => {
+                if (finished) return
+                finished = true
+                try { fakeServer.close() } catch {}
+                done(err)
+            }
+
+            fakeServer.on('message', (msg, rinfo) => {
+                serverOscore.decode(msg).then(async (decoded) => {
+                    requestCount++
+                    const innerReq = parse(decoded)
+                    const outerReq = parse(msg)
+                    const uriQuery = innerReq.options.find((opt) => opt.name === 'Uri-Query')
+
+                    if (requestCount === 1) {
+                        // Sanity check: the original request must carry the Uri-Query
+                        // the client set before we can meaningfully assert it survives
+                        // the retry.
+                        if (uriQuery == null || uriQuery.value.toString() !== 'tu=abc123') {
+                            finish(new Error(`first request missing Uri-Query, got: ${JSON.stringify(innerReq.options)}`))
+                            return
+                        }
+
+                        // Issue a 4.01 + Echo freshness challenge (RFC 8613 Appendix
+                        // B.1.2 / RFC 9175) — the agent should transparently retry.
+                        const echoNonce = Buffer.from('aabbccddeeff0011', 'hex')
+                        const challenge = generate({
+                            code: '4.01',
+                            ack: innerReq.confirmable,
+                            messageId: outerReq.messageId,
+                            token: innerReq.token,
+                            options: [{ name: '252' as any, value: echoNonce }]
+                        })
+                        const encryptedChallenge = await serverOscore.encode(challenge)
+                        fakeServer.send(encryptedChallenge, 0, encryptedChallenge.length, rinfo.port, rinfo.address)
+                        return
+                    }
+
+                    // Second request: the agent's transparent Echo auto-retry. It
+                    // must still carry the original Uri-Query — GWLB-2727 is the
+                    // agent dropping it here.
+                    if (uriQuery == null) {
+                        finish(new Error('retry request dropped the Uri-Query option (GWLB-2727)'))
+                        return
+                    }
+                    if (uriQuery.value.toString() !== 'tu=abc123') {
+                        finish(new Error(`retry Uri-Query value changed, got: ${uriQuery.value.toString()}`))
+                        return
+                    }
+
+                    const response = generate({
+                        code: '2.05',
+                        ack: innerReq.confirmable,
+                        messageId: outerReq.messageId,
+                        token: innerReq.token,
+                        payload: Buffer.from('ok-after-echo')
+                    })
+                    const encryptedResponse = await serverOscore.encode(response)
+                    fakeServer.send(encryptedResponse, 0, encryptedResponse.length, rinfo.port, rinfo.address)
+                }).catch((err) => {
+                    finish(err as Error)
+                })
+            })
+
+            fakeServer.bind(port, () => {
+                const agent = trackAgent(new Agent({ type: 'udp4' }))
+                agent.addOscoreContext('127.0.0.1', port, clientOscore)
+
+                const req = request({
+                    hostname: '127.0.0.1',
+                    port,
+                    pathname: '/test',
+                    agent
+                })
+                req.setOption('Uri-Query', Buffer.from('tu=abc123'))
+                req.on('error', (err) => {
+                    finish(new Error(`request errored unexpectedly: ${err.message}`))
+                })
+                req.on('response', (res) => {
+                    try {
+                        expect(res.payload.toString()).to.equal('ok-after-echo')
+                        expect(requestCount).to.equal(2)
+                        finish()
+                    } catch (e) {
+                        finish(e as Error)
+                    }
+                })
+                req.end()
+            })
+        }).timeout(2000)
+    })
 })


### PR DESCRIPTION
## Summary

The client-side Echo auto-retry (RFC 8613 Appendix B.1.2 / RFC 9175) added in #397 skips `Uri-Query` when copying options onto the retried request, on the assumption it would be reconstructed from `retryUrl` the same way `Uri-Path` and `Observe` are. There is no such reconstruction path for `Uri-Query` in this library — `CoapRequestParams` has no `query` field, so it is only ever set via `setOption('Uri-Query', ...)` on the original request — meaning the retry silently drops it.

Reported downstream as a real interop bug: a client sends `GET /resource?param=value` over OSCORE, the server issues a `4.01 Unauthorized` + `Echo` freshness challenge on the first request after a context reset (fresh boot / no persisted replay window), and the auto-retried request arrives without the query parameters — servers that require them then reject the retry with `4.00 Bad Request`.

## Fix

`lib/agent.ts`: remove `Uri-Query` from the option skip-list in the Echo auto-retry path. Only `Uri-Path` and `Observe` are actually reconstructed from `retryUrl` (via `url.pathname` / `url.observe`), so those stay skipped; every other option — including `Uri-Query` — is copied through unchanged, matching a plain PDU-clone-and-add-Echo retry (e.g. `coap_pdu_duplicate` in libcoap).

## Tests

`test/oscore.ts`: new regression test (`client-side Echo auto-retry`) using a raw OSCORE fake-server harness (same pattern as the existing "non-OSCORE messages from OSCORE peer" tests) that issues a `4.01` + `Echo` challenge on the first request and asserts the retried request still carries the original `Uri-Query` option. Confirmed it fails on the pre-fix code and passes after.

Full suite: 506 passing, 3 pre-existing unrelated `multicast` failures (network-environment timeouts, untouched by this change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)